### PR TITLE
fix unicode text that failed build on linux

### DIFF
--- a/src/main/java/com/google/security/zynamics/binnavi/Gui/MainWindow/ProjectTree/Nodes/TagContainer/Component/CTagContainerNodeComponent.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Gui/MainWindow/ProjectTree/Nodes/TagContainer/Component/CTagContainerNodeComponent.java
@@ -128,13 +128,13 @@ public final class CTagContainerNodeComponent extends CAbstractNodeComponent {
     @Override
     public void deletedTag(final CTagManager manager, final ITreeNode<CTag> parent,
         final ITreeNode<CTag> tag) {
-      // container node can´t be deleted
+      // container node can't be deleted
     }
 
     @Override
     public void deletedTagSubtree(final CTagManager manager, final ITreeNode<CTag> parent,
         final ITreeNode<CTag> tag) {
-      // container node subtree can´t be deleted
+      // container node subtree can't be deleted
     }
 
     @Override


### PR DESCRIPTION
the error output was:

```
build-binnavi-jar:
   [delete] Deleting directory /binnavi/target/classes
    [mkdir] Created dir: /binnavi/target/classes                           
    [javac] Compiling 2449 source files to /binnavi/target/classes
    [javac] /binnavi/src/main/java/com/google/security/zynamics/binnavi/Gui/MainWindow/ProjectTree/Nodes/TagContainer/Component/CTagContainerNodeComponent.java:131: error: unmappable character for encoding ASCII
    [javac]       // container node can??t be deleted
    [javac]                            ^
    [javac] /binnavi/src/main/java/com/google/security/zynamics/binnavi/Gui/MainWindow/ProjectTree/Nodes/TagContainer/Component/CTagContainerNodeComponent.java:131: error: unmappable character for encoding ASCII
    [javac]       // container node can??t be deleted
    [javac]                             ^
    [javac] /binnavi/src/main/java/com/google/security/zynamics/binnavi/Gui/MainWindow/ProjectTree/Nodes/TagContainer/Component/CTagContainerNodeComponent.java:137: error: unmappable character for encoding ASCII
    [javac]       // container node subtree can??t be deleted
    [javac]                                    ^
    [javac] /binnavi/src/main/java/com/google/security/zynamics/binnavi/Gui/MainWindow/ProjectTree/Nodes/TagContainer/Component/CTagContainerNodeComponent.java:137: error: unmappable character for encoding ASCII
    [javac]       // container node subtree can??t be deleted
    [javac]                                     ^
    [javac] 4 errors

BUILD FAILED
/binnavi/src/main/java/com/google/security/zynamics/build.xml:161: Compile failed; see the compiler error output for details.
```
