### PR TITLE
Fix module initialization when bn_sections, bn_types, bn_type_instances, or bn_base_types has a single row.

### DIFF
--- a/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/PostgreSQLDataImporter.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/PostgreSQLDataImporter.java
@@ -132,8 +132,9 @@ public final class PostgreSQLDataImporter {
     connection.executeUpdate(query, true);
 
     final String updateSequence =
-        String.format("SELECT setval('bn_base_types_id_seq', MAX(id)) from %s",
-            CTableNames.BASE_TYPES_TABLE);
+        String.format("SELECT setval('bn_base_types_id_seq', " +
+                      "COALESCE((SELECT MAX(id) + 1 FROM %s), 1), false) from %s",
+            CTableNames.BASE_TYPES_TABLE, CTableNames.BASE_TYPES_TABLE);
     connection.executeQuery(updateSequence, true);
   }
 
@@ -316,7 +317,9 @@ public final class PostgreSQLDataImporter {
     connection.executeUpdate(query, true);
 
     final String updateSequence = String.format(
-        "SELECT setval('bn_types_id_seq', MAX(id)) from %s", CTableNames.TYPE_MEMBERS_TABLE);
+        "SELECT setval('bn_types_id_seq', " +
+        "COALESCE((SELECT MAX(id) + 1 FROM %s), 1), false) from %s",
+        CTableNames.TYPE_MEMBERS_TABLE, CTableNames.TYPE_MEMBERS_TABLE);
     connection.executeQuery(updateSequence, true);
   }
 }

--- a/src/main/java/com/google/security/zynamics/binnavi/data/postgresql_tables.sql
+++ b/src/main/java/com/google/security/zynamics/binnavi/data/postgresql_tables.sql
@@ -2272,7 +2272,8 @@ DECLARE
   EXECUTE 'INSERT INTO bn_base_types
            SELECT '|| moduleid ||', id, name, size, pointer, signed, category::text::type_category
            FROM ex_'|| rawmoduleid ||'_base_types';
-  EXECUTE 'SELECT setval(''bn_base_types_id_seq'', MAX(id)) FROM bn_base_types';
+  EXECUTE 'SELECT setval(''bn_base_types_id_seq'', COALESCE((SELECT MAX(id) + 1 FROM bn_base_types), 1), false)
+           FROM bn_base_types';
 
   --
   -- import types.
@@ -2282,7 +2283,8 @@ DECLARE
            SELECT '|| moduleid ||', raw_types.id, raw_types.name, raw_types.base_type, raw_types.parent_id,
            raw_types.offset, raw_types.argument, raw_types.number_of_elements
            FROM ex_'|| rawmoduleid ||'_types AS raw_types';
-  EXECUTE 'SELECT setval(''bn_types_id_seq'', MAX(id)) FROM bn_types';
+  EXECUTE 'SELECT setval(''bn_types_id_seq'', COALESCE((SELECT MAX(id) + 1 FROM bn_types), 1), false)
+           FROM bn_types';
 
   --
   -- import expression types.
@@ -2299,7 +2301,8 @@ DECLARE
   EXECUTE 'INSERT INTO bn_sections (module_id, id, name, comment_id, start_address, end_address, permission, data)
            SELECT '|| moduleid ||', id, name, NULL, start_address, end_address, permission::text::permission_type, data
 		   FROM ex_'|| rawmoduleid ||'_sections';
-  EXECUTE 'SELECT setval(''bn_sections_id_seq'', MAX(id)) FROM bn_sections';
+  EXECUTE 'SELECT setval(''bn_sections_id_seq'', COALESCE((SELECT MAX(id) + 1 FROM bn_sections), 1), false)
+           FROM bn_sections';
 
   --
   -- import type instances
@@ -2308,7 +2311,8 @@ DECLARE
   EXECUTE 'INSERT INTO bn_type_instances (module_id, id, name, type_id, section_id, section_offset)
            SELECT '|| moduleid ||', id, name, type_id, section_id, section_offset
            FROM ex_'|| rawmoduleid ||'_type_instances';
-  EXECUTE 'SELECT setval(''bn_type_instances_id_seq'', MAX(id)) FROM bn_type_instances';
+  EXECUTE 'SELECT setval(''bn_type_instances_id_seq'', COALESCE((SELECT MAX(id) + 1 FROM bn_type_instances), 1), false)
+           FROM bn_type_instances';
 
   --
   -- import expression type instances

--- a/src/test/java/com/google/security/zynamics/binnavi/testdata/database_schema.sql
+++ b/src/test/java/com/google/security/zynamics/binnavi/testdata/database_schema.sql
@@ -3160,7 +3160,8 @@ DECLARE
   EXECUTE 'INSERT INTO bn_base_types
            SELECT '|| moduleid ||', id, name, size, pointer, signed, category::text::type_category
            FROM ex_'|| rawmoduleid ||'_base_types';
-  EXECUTE 'SELECT setval(''bn_base_types_id_seq'', MAX(id)) FROM bn_base_types';
+  EXECUTE 'SELECT setval(''bn_base_types_id_seq'', COALESCE((SELECT MAX(id) + 1 FROM bn_base_types), 1), false)
+           FROM bn_base_types';
 
   --
   -- import types.
@@ -3170,7 +3171,8 @@ DECLARE
            SELECT '|| moduleid ||', raw_types.id, raw_types.name, raw_types.base_type, raw_types.parent_id,
            raw_types.offset, raw_types.argument, raw_types.number_of_elements
            FROM ex_'|| rawmoduleid ||'_types AS raw_types';
-  EXECUTE 'SELECT setval(''bn_types_id_seq'', MAX(id)) FROM bn_types';
+  EXECUTE 'SELECT setval(''bn_types_id_seq'', COALESCE((SELECT MAX(id) + 1 FROM bn_types), 1), false)
+           FROM bn_types';
 
   --
   -- import expression types.
@@ -3187,7 +3189,8 @@ DECLARE
   EXECUTE 'INSERT INTO bn_sections (module_id, id, name, comment_id, start_address, end_address, permission, data)
            SELECT '|| moduleid ||', id, name, NULL, start_address, end_address, permission::text::permission_type, data
 		   FROM ex_'|| rawmoduleid ||'_sections';
-  EXECUTE 'SELECT setval(''bn_sections_id_seq'', MAX(id)) FROM bn_sections';
+  EXECUTE 'SELECT setval(''bn_sections_id_seq'', COALESCE((SELECT MAX(id) + 1 FROM bn_sections), 1), false)
+           FROM bn_sections';
 
   --
   -- import type instances
@@ -3196,7 +3199,8 @@ DECLARE
   EXECUTE 'INSERT INTO bn_type_instances (module_id, id, name, type_id, section_id, section_offset)
            SELECT '|| moduleid ||', id, name, type_id, section_id, section_offset
            FROM ex_'|| rawmoduleid ||'_type_instances';
-  EXECUTE 'SELECT setval(''bn_type_instances_id_seq'', MAX(id)) FROM bn_type_instances';
+  EXECUTE 'SELECT setval(''bn_type_instances_id_seq'', COALESCE((SELECT MAX(id) + 1 FROM bn_type_instances), 1), false)
+           FROM bn_type_instances';
 
   --
   -- import expression type instances


### PR DESCRIPTION
If the first IDB you import after creating a new database only has a single segment, then Postgres will throw an error when the module is initialized.

The problem can be triggered by starting from any application:
1. Generate a raw binary: `objcopy -O binary hello_world hello_world.bin`
2. Load `hello_world.bin` in IDA
3. Save the IDB and import it in BinNavi
4. Attempt to initialize the imported module.

The error is thrown by the statement `SELECT setval(''bn_sections_id_seq'', MAX(id)) FROM bn_sections` in `import(...)`, which fails when `MAX(id)` evaluates to zero.

This patch replaces all instances of that construct with the more general `setval(..., COALESCE((SELECT MAX(id) + 1 FROM table), 1), false)` suggested in http://stackoverflow.com/a/244265.
