### PR TITLE
Force travis to build with JDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
-
+jdk:
+  - oraclejdk8
+sudo: false
 script:
-
   - mvn dependency:copy-dependencies
   - ant build-binnavi-fat-jar


### PR DESCRIPTION
At current Travis is using its default JDK causing the following error to appear after every `javac`:

```
$ ant build-binnavi-fat-jar

Buildfile: /home/travis/build/google/binnavi/build.xml

clean:

build-revision:

    [mkdir] Created dir: /home/travis/build/google/binnavi/target/classes/com/google/security/zynamics/binnavi/data

[propertyfile] Creating new property file: /home/travis/build/google/binnavi/target/classes/com/google/security/zynamics/binnavi/data/build-data.properties

build-zylib-jar:

    [javac] Compiling 375 source files to /home/travis/build/google/binnavi/target/classes

    [javac] warning: /home/travis/build/google/binnavi/src/main/java/com/google/security/zynamics/lib/yfileswrap-obfuscated.jar(com/google/security/zynamics/zylib/yfileswrap/gui/zygraph/settings/ILayoutSettings.class): major version 52 is newer than 51, the highest major version supported by this compiler.

    [javac]   It is recommended that the compiler be upgraded.

    [javac] warning: /home/travis/build/google/binnavi/src/main/java/com/google/security/zynamics/lib/yfileswrap-obfuscated.jar(com/google/security/zynamics/zylib/yfileswrap/gui/zygraph/AbstractZyGraph.class): major version 52 is newer than 51, the highest major version supported by this compiler.

    [javac]   It is recommended that the compiler be upgraded.

    [javac] warning: /home/travis/build/google/binnavi/src/main/java/com/google/security/zynamics/lib/yfileswrap-obfuscated.jar(com/google/security/zynamics/zylib/yfileswrap/gui/zygraph/realizers/IZyNodeRealizer.class): major version 52 is newer than 51, the highest major version supported by this compiler.

    [javac]   It is recommended that the compiler be upgraded.

    [javac] warning: /home/travis/build/google/binnavi/src/main/java/com/google/security/zynamics/lib/yfileswrap-obfuscated.jar(com/google/security/zynamics/zylib/yfileswrap/gui/zygraph/editmode/ZyEditMode.class): major version 52 is newer than 51, the highest major version supported by this compiler.

    [javac]   It is recommended that the compiler be upgraded.

    [javac] warning: /home/travis/build/google/binnavi/src/main/java/com/google/security/zynamics/lib/yfileswrap-obfuscated.jar(com/google/security/zynamics/zylib/yfileswrap/gui/zygraph/edges/ZyGraphEdge.class): major version 52 is newer than 51, the highest major version supported by this compiler.
....
```

This is because in [pom.xml](https://github.com/google/binnavi/blob/master/pom.xml#L125-L126) the source and target appear to be 1.7, which Travis is not using. This change will make travis use 1.8 for now on. Does not change build process. When tested on my Travis I now get the following:

```
$ ant build-binnavi-fat-jar

Buildfile: /home/travis/build/lordqwerty/binnavi/build.xml

clean:

build-revision:

    [mkdir] Created dir: /home/travis/build/lordqwerty/binnavi/target/classes/com/google/security/zynamics/binnavi/data

[propertyfile] Creating new property file: /home/travis/build/lordqwerty/binnavi/target/classes/com/google/security/zynamics/binnavi/data/build-data.properties

build-zylib-jar:

    [javac] Compiling 375 source files to /home/travis/build/lordqwerty/binnavi/target/classes

    [javac] Note: Some input files use or override a deprecated API.

    [javac] Note: Recompile with -Xlint:deprecation for details.

     [copy] Copying 14 files to /home/travis/build/lordqwerty/binnavi/target/classes/com/google/security/zynamics/zylib/resources

      [jar] Building jar: /home/travis/build/lordqwerty/binnavi/target/zylib.jar

build-reil-jar:

    [javac] Compiling 1149 source files to /home/travis/build/lordqwerty/binnavi/target/classes

      [jar] Building jar: /home/travis/build/lordqwerty/binnavi/target/reil.jar

build-binnavi-jar:

    [javac] Compiling 2449 source files to /home/travis/build/lordqwerty/binnavi/target/classes

    [javac] Note: Some input files use or override a deprecated API.

    [javac] Note: Recompile with -Xlint:deprecation for details.

     [copy] Copying 235 files to /home/travis/build/lordqwerty/binnavi/target/classes/com/google/security/zynamics/binnavi/data

     [copy] Copying 5 files to /home/travis/build/lordqwerty/binnavi/target/classes/com/google/security/zynamics/binnavi/exporters

     [copy] Copying 3 files to /home/travis/build/lordqwerty/binnavi/target/classes/com/google/security/zynamics/binnavi/standardplugins/pathfinder/resources

      [jar] Building jar: /home/travis/build/lordqwerty/binnavi/target/binnavi.jar

build-binnavi-fat-jar:

    [mkdir] Created dir: /home/travis/build/lordqwerty/binnavi/target/staging

      [jar] Building jar: /home/travis/build/lordqwerty/binnavi/target/binnavi-all.jar

BUILD SUCCESSFUL

Total time: 59 seconds
```

Maven is now much happier. Might also prevent future compilation issues.
