### PR TITLE
Update Database.java

### DIFF
--- a/src/main/java/com/google/security/zynamics/binnavi/API/disassembly/Database.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/API/disassembly/Database.java
@@ -432,11 +432,9 @@ public final class Database implements ApiObject<IDatabase> {
     if (!isLoaded()) {
       try {
         load();
-      } catch (final CouldntLoadDataException e) {
+      } catch (CouldntLoadDataException | InvalidDatabaseVersionException e) {
         return new ArrayList<Project>();
-      } catch (final InvalidDatabaseVersionException e) {
-        return new ArrayList<Project>();
-      }
+      } 
     }
 
     return new ArrayList<Project>(m_projects);
@@ -549,13 +547,11 @@ public final class Database implements ApiObject<IDatabase> {
   public void load() throws CouldntLoadDataException, InvalidDatabaseVersionException {
     try {
       m_database.load();
-    } catch (final com.google.security.zynamics.binnavi.Database.Exceptions.CouldntLoadDataException e) {
+    } catch (com.google.security.zynamics.binnavi.Database.Exceptions.CouldntLoadDataException | LoadCancelledException e) {
       throw new CouldntLoadDataException(e);
     } catch (final com.google.security.zynamics.binnavi.Database.Exceptions.InvalidDatabaseVersionException e) {
       throw new InvalidDatabaseVersionException(e);
-    } catch (final LoadCancelledException e) {
-      throw new CouldntLoadDataException(e);
-    }
+    } 
   }
 
   // ! Refreshes the modules list.

--- a/src/main/java/com/google/security/zynamics/binnavi/API/disassembly/Database.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/API/disassembly/Database.java
@@ -378,11 +378,9 @@ public final class Database implements ApiObject<IDatabase> {
     if (!isLoaded()) {
       try {
         load();
-      } catch (final CouldntLoadDataException e) {
+      } catch (CouldntLoadDataException | InvalidDatabaseVersionException e) {
         return new ArrayList<Module>();
-      } catch (final InvalidDatabaseVersionException e) {
-        return new ArrayList<Module>();
-      }
+      } 
     }
 
     return new ArrayList<Module>(m_modules);


### PR DESCRIPTION
Exclude unnecessary catch clause in the `getModules()` method. Reserved word `final` was deleted, because parameter `e`, if we catching multiple exception types, will be `final` by default (according to [oracle documentation](https://docs.oracle.com/javase/7/docs/technotes/guides/language/catch-multiple.html)).

Do the same to `getProjects()` and `load()` methods in the seccond commit.
