### PR TITLE
Excluding unnecessary finally blocks and close operations

### DIFF
--- a/src/main/java/com/google/security/zynamics/binnavi/Database/NodeParser/OperandTreeNode.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/NodeParser/OperandTreeNode.java
@@ -100,10 +100,9 @@ public final class OperandTreeNode {
       final Integer instanceId,
       final int operandPosition,
       final IAddress address) {
-    Preconditions.checkNotNull(value, "IE01298: Value argument can not be null");
+    m_value = Preconditions.checkNotNull(value, "IE01298: Value argument can not be null");
     m_id = operandId;
     m_type = type;
-    m_value = value;
     m_parentId = parentId;
     m_replacement = replacement;
     m_reference = references;

--- a/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Creators/PostgreSQLProjectCreator.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Creators/PostgreSQLProjectCreator.java
@@ -91,10 +91,7 @@ public final class PostgreSQLProjectCreator {
 
     NaviLogger.info("Creating new project %s", name);
 
-    try {
-      final String query =
-
-          "INSERT INTO "
+      final String query = "INSERT INTO "
               + CTableNames.PROJECTS_TABLE
               + "(name, description, creation_date, modification_date) VALUES(?, '', NOW(), NOW()) RETURNING id";
 

--- a/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Creators/PostgreSQLProjectCreator.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Creators/PostgreSQLProjectCreator.java
@@ -55,9 +55,7 @@ public final class PostgreSQLProjectCreator {
         "select id, name, description, creation_date, modification_date from "
             + CTableNames.PROJECTS_TABLE + " where id = " + projectId;
 
-    final ResultSet resultSet = provider.getConnection().executeQuery(query, true);
-
-    try {
+    try (ResultSet resultSet = provider.getConnection().executeQuery(query, true)) {
       while (resultSet.next()) {
         final String name = PostgreSQLHelpers.readString(resultSet, "name");
         final String description = PostgreSQLHelpers.readString(resultSet, "description");
@@ -68,10 +66,8 @@ public final class PostgreSQLProjectCreator {
         return new CProject(projectId, name, description, creationDate, modificationDate,
             addressSpaceCount, new ArrayList<DebuggerTemplate>(), provider);
       }
-    } finally {
-      resultSet.close();
     }
-
+    
     return null;
   }
 
@@ -102,35 +98,25 @@ public final class PostgreSQLProjectCreator {
               + CTableNames.PROJECTS_TABLE
               + "(name, description, creation_date, modification_date) VALUES(?, '', NOW(), NOW()) RETURNING id";
 
-
-      final PreparedStatement statement =
+        try (PreparedStatement statement =
           connection.getConnection().prepareStatement(query, ResultSet.TYPE_SCROLL_INSENSITIVE,
               ResultSet.CONCUR_READ_ONLY);
-
-      try {
+           ResultSet resultSet = statement.executeQuery()) {
         statement.setString(1, name);
-
-        final ResultSet resultSet = statement.executeQuery();
 
         Integer id = null;
 
-        try {
           while (resultSet.next()) {
             if (resultSet.isFirst()) {
               id = resultSet.getInt(1);
               break;
             }
           }
-        } finally {
-          resultSet.close();
-        }
+        
         Preconditions.checkNotNull(id,
             "IE02044: Error id for a project after creation may not be null");
 
         return PostgreSQLProjectCreator.loadProject(provider, id);
-      } finally {
-        statement.close();
-      }
     } catch (final SQLException e) {
       throw new CouldntSaveDataException(e);
     }

--- a/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/PostgreSQLDataImporter.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/PostgreSQLDataImporter.java
@@ -56,17 +56,13 @@ public final class PostgreSQLDataImporter {
       throws SQLException {
     Preconditions.checkNotNull(connection, "IE00207: provider argument can not be null");
 
-    final ResultSet resultSet =
-        connection.executeQuery("SELECT architecture FROM modules WHERE id = " + rawModuleId, true);
-
-    try {
+    try (ResultSet resultSet =
+        connection.executeQuery("SELECT architecture FROM modules WHERE id = " + rawModuleId, true)) {
       while (resultSet.next()) {
         return PostgreSQLHelpers.readString(resultSet, "architecture");
       }
 
       throw new SQLException("Error: Could not determine architecture of new module");
-    } finally {
-      resultSet.close();
     }
   }
 

--- a/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/PostgreSQLHelpers.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/PostgreSQLHelpers.java
@@ -148,18 +148,13 @@ public class PostgreSQLHelpers {
   public static int getBackendPID(final CConnection connection) {
     Preconditions.checkNotNull(connection, "IE02410: connection argument can not be null");
 
-    try {
-      final String query = "SELECT pg_backend_pid() AS pid";
+    final String query = "SELECT pg_backend_pid() AS pid";
+    try (ResultSet pidResult = connection.executeQuery(query, true)) {
 
-      final ResultSet pidResult = connection.executeQuery(query, true);
-
-      try {
         while (pidResult.next()) {
           return pidResult.getInt("pid");
         }
-      } finally {
-        pidResult.close();
-      }
+
     } catch (final SQLException exception) {
       CUtilityFunctions.logException(exception);
     }
@@ -206,18 +201,13 @@ public class PostgreSQLHelpers {
     Preconditions.checkNotNull(connection, "IE00602: Connection argument can not be null");
     Preconditions.checkArgument(id >= 0, "IE00605: Id argument can not less then zero");
 
-    try {
-      final String query = "SELECT modification_date FROM " + targetTable + " WHERE id = " + id;
+    final String query = "SELECT modification_date FROM " + targetTable + " WHERE id = " + id;
+    try (ResultSet dateResult = connection.executeQuery(query, true)) {
 
-      final ResultSet dateResult = connection.executeQuery(query, true);
-
-      try {
         while (dateResult.next()) {
           return dateResult.getTimestamp("modification_date");
         }
-      } finally {
-        dateResult.close();
-      }
+      
     } catch (final SQLException e) {
       throw new CouldntLoadDataException(e);
     }
@@ -250,21 +240,14 @@ public class PostgreSQLHelpers {
 
     final IFilledList<INaviView> views = new FilledList<INaviView>();
 
-    try {
-      final ResultSet resultSet = connection.executeQuery(query, true);
-
-      try {
+    try (ResultSet resultSet = connection.executeQuery(query, true)) {
+        
         while (resultSet.next()) {
           final int containerId = resultSet.getInt(columnName);
           final int viewId = resultSet.getInt("view_id");
-
           final INaviView view = finder.findView(containerId, viewId);
-
           views.add(view);
         }
-      } finally {
-        resultSet.close();
-      }
 
       return views;
     } catch (final SQLException exception) {
@@ -292,14 +275,10 @@ public class PostgreSQLHelpers {
         + " (SELECT oid FROM pg_class WHERE relname = '%s') AND attname = '%s';", tableName,
         columnName);
 
-    try {
-      final ResultSet result = connection.executeQuery(query, true);
+    try (ResultSet result = connection.executeQuery(query, true)) {
 
-      try {
-        return result.first();
-      } finally {
-        result.close();
-      }
+      return result.first();
+
     } catch (final SQLException e) {
       return false;
     }
@@ -322,14 +301,10 @@ public class PostgreSQLHelpers {
 
     final String query = "SELECT relname FROM pg_class WHERE relname = '" + tableName + "'";
 
-    try {
-      final ResultSet result = connection.executeQuery(query, true);
+    try (ResultSet result = connection.executeQuery(query, true)) {
 
-      try {
-        return result.first();
-      } finally {
-        result.close();
-      }
+      return result.first();
+      
     } catch (final SQLException e) {
       throw new CouldntLoadDataException(e);
     }
@@ -358,16 +333,12 @@ public class PostgreSQLHelpers {
     builder.deleteCharAt(builder.length() - 1);
     builder.append(")");
 
-    try {
-      final ResultSet result = connection.executeQuery(builder.toString(), true);
+    try (ResultSet result = connection.executeQuery(builder.toString(), true)) {
 
-      try {
         while (result.next()) {
           return result.getInt("count");
         }
-      } finally {
-        result.close();
-      }
+      
     } catch (final SQLException e) {
       throw new CouldntLoadDataException(e);
     }
@@ -449,17 +420,12 @@ public class PostgreSQLHelpers {
     final String query =
         "UPDATE " + table + " SET description = ?, modification_date = NOW() WHERE id = ?";
 
-    try {
-      final PreparedStatement statement = connection.getConnection().prepareStatement(query);
-
-      try {
-        statement.setString(1, description);
-        statement.setInt(2, id);
-
-        statement.executeUpdate();
-      } finally {
-        statement.close();
-      }
+    try (PreparedStatement statement = connection.getConnection().prepareStatement(query)) {
+    
+      statement.setString(1, description);
+      statement.setInt(2, id);
+      statement.executeUpdate();
+      
     } catch (final SQLException e) {
       throw new CouldntSaveDataException(e);
     }
@@ -487,17 +453,12 @@ public class PostgreSQLHelpers {
     final String query =
         "UPDATE " + tableName + " SET name = ?, modification_date = NOW() WHERE id = ?";
 
-    try {
-      final PreparedStatement statement = connection.getConnection().prepareStatement(query);
-
-      try {
-        statement.setString(1, name);
-        statement.setInt(2, id);
-
-        statement.executeUpdate();
-      } finally {
-        statement.close();
-      }
+    try (PreparedStatement statement = connection.getConnection().prepareStatement(query)) {
+    
+      statement.setString(1, name);
+      statement.setInt(2, id);
+      statement.executeUpdate();
+      
     } catch (final SQLException e) {
       throw new CouldntSaveDataException(e);
     }
@@ -519,15 +480,11 @@ public class PostgreSQLHelpers {
 
     final String query = "UPDATE " + tableName + " SET modification_date = NOW() WHERE id = ?";
 
-    try {
-      final PreparedStatement statement = connection.getConnection().prepareStatement(query);
-      try {
-        statement.setInt(1, id);
-
-        statement.executeUpdate();
-      } finally {
-        statement.close();
-      }
+    try (PreparedStatement statement = connection.getConnection().prepareStatement(query)) {
+      
+      statement.setInt(1, id);
+      statement.executeUpdate();
+      
     } catch (final SQLException e) {
       throw new CouldntSaveDataException(e);
     }

--- a/src/main/java/com/google/security/zynamics/zylib/io/StreamUtils.java
+++ b/src/main/java/com/google/security/zynamics/zylib/io/StreamUtils.java
@@ -39,8 +39,8 @@ public class StreamUtils {
    * @throws IOException if an IO error occurs.
    */
   public static List<String> readLinesFromReader(final Reader reader) throws IOException {
-    final BufferedReader br = new BufferedReader(reader);
-    try {
+  
+    try (BufferedReader br = new BufferedReader(reader)) {
       final List<String> lines = new ArrayList<String>();
       String line;
       while (true) {
@@ -50,8 +50,6 @@ public class StreamUtils {
         }
         lines.add(line);
       }
-    } finally {
-      br.close();
     }
   }
 }

--- a/src/main/java/com/google/security/zynamics/zylib/net/WebsiteReader.java
+++ b/src/main/java/com/google/security/zynamics/zylib/net/WebsiteReader.java
@@ -50,27 +50,19 @@ public class WebsiteReader {
 
     conn.setDoOutput(true);
 
-    final OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream());
-    try {
+    try (OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream())) {
       wr.write(encodedData);
       wr.flush();
-    } finally {
-      wr.close();
     }
 
     // Get the response
-    final BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-
     final StringBuilder ret = new StringBuilder();
-
     String line;
 
-    try {
+    try (BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
       while ((line = rd.readLine()) != null) {
         ret.append(line);
       }
-    } finally {
-      rd.close();
     }
 
     return ret.toString();


### PR DESCRIPTION
Change `try-finally` block to the Java7's `try-with-resources` construction. Finally blocks and close operations can be excluded becouse `PreparedStatement` and `ResultSet` classes implement `AutoCloseable` intrface
