### PR TITLE
Excluding unnecessary finally blocks and close operations (part 2)

### DIFF
--- a/src/main/java/com/google/security/zynamics/binnavi/Database/CConnection.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/CConnection.java
@@ -243,9 +243,7 @@ public final class CConnection {
 
     int result = 0;
 
-    final PreparedStatement prep = m_connection.prepareStatement(query);
-
-    try {
+    try (PreparedStatement prep = m_connection.prepareStatement(query)) {
       result = prep.executeUpdate();
     } catch (final SQLException error) {
       if (m_performanceOutput) {
@@ -262,9 +260,7 @@ public final class CConnection {
       } else {
         throw error;
       }
-    } finally {
-      prep.close();
-    }
+    } 
 
     if (m_performanceOutput) {
       militime -= new GregorianCalendar().getTimeInMillis();
@@ -297,15 +293,9 @@ public final class CConnection {
     if (m_connection == null) {
       return false;
     }
-    try {
-      final Statement statement = m_connection.createStatement();
+    try (Statement statement = m_connection.createStatement()) {
       // do something about the timeout.
-      try {
         statement.execute("SELECT 1;");
-      } finally {
-        // do something about the timeout.
-        statement.close();
-      }
       return true;
     } catch (final SQLException exception) {
       NaviLogger

--- a/src/main/java/com/google/security/zynamics/binnavi/Database/CGenericSQLUserFunctions.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/CGenericSQLUserFunctions.java
@@ -54,19 +54,15 @@ public class CGenericSQLUserFunctions {
 
     CUser user = null;
 
-    try {
-      final PreparedStatement statement = connection.prepareStatement(query);
-
-      try {
+    try (PreparedStatement statement = connection.prepareStatement(query);
+         ResultSet resultSet = statement.executeQuery()) {
+        
         statement.setString(1, userName);
-        final ResultSet resultSet = statement.executeQuery();
-
+       
         while (resultSet.next()) {
           user = new CUser(resultSet.getInt(1), userName);
         }
-      } finally {
-        statement.close();
-      }
+     
     } catch (final SQLException exception) {
       throw new CouldntSaveDataException(exception);
     }
@@ -91,15 +87,10 @@ public class CGenericSQLUserFunctions {
 
     final String query = "DELETE FROM " + CTableNames.USER_TABLE + " WHERE user_id = ?;";
 
-    try {
-      final PreparedStatement statement = connection.prepareStatement(query);
-
-      try {
+    try (PreparedStatement statement = connection.prepareStatement(query)) {
+     
         statement.setInt(1, user.getUserId());
         statement.execute();
-      } finally {
-        statement.close();
-      }
 
     } catch (final SQLException exception) {
       throw new CouldntDeleteException(exception);
@@ -127,17 +118,11 @@ public class CGenericSQLUserFunctions {
     final String query =
         "UPDATE " + CTableNames.USER_TABLE + " SET user_name = ? WHERE user_id = ?;";
 
-    try {
-      final PreparedStatement statement = connection.prepareStatement(query);
-
-      try {
+    try (PreparedStatement statement = connection.prepareStatement(query)) {
+      
         statement.setString(1, userName);
         statement.setInt(2, user.getUserId());
-
         statement.execute();
-      } finally {
-        statement.close();
-      }
 
     } catch (final SQLException exception) {
       throw new CouldntSaveDataException(exception);
@@ -161,15 +146,13 @@ public class CGenericSQLUserFunctions {
 
     final String query = "SELECT user_id, user_name FROM " + CTableNames.USER_TABLE;
 
-    final ArrayList<IUser> users = new ArrayList<IUser>();
+    final ArrayList<IUser> users = new ArrayList<>();
 
-    try {
-      final ResultSet resultSet = connection.executeQuery(query, true);
-
+    try (ResultSet resultSet = connection.executeQuery(query, true)) {
+    
       while (resultSet.next()) {
         final int userId = resultSet.getInt(1);
         final String userName = resultSet.getString(2);
-
         users.add(new CUser(userId, userName));
       }
 

--- a/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Functions/PostgreSQLFunctionFunctions.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Functions/PostgreSQLFunctionFunctions.java
@@ -68,17 +68,13 @@ public final class PostgreSQLFunctionFunctions {
 
     final String storedProcedure = " { ? = call append_function_comment( ?, ?, ?, ?) } ";
 
-    try {
-      final CallableStatement appendCommentProcedure = connection.prepareCall(storedProcedure);
+    try (CallableStatement appendCommentProcedure = connection.prepareCall(storedProcedure)) {
 
-      try {
         appendCommentProcedure.registerOutParameter(1, Types.INTEGER);
-
         appendCommentProcedure.setInt(2, moduleId);
         appendCommentProcedure.setObject(3, function.getAddress().toBigInteger(), Types.BIGINT);
         appendCommentProcedure.setInt(4, userId);
         appendCommentProcedure.setString(5, commentText);
-
         appendCommentProcedure.execute();
 
         final int commentId = appendCommentProcedure.getInt(1);
@@ -86,9 +82,6 @@ public final class PostgreSQLFunctionFunctions {
           throw new CouldntSaveDataException("Error: Got an comment id of null from the database");
         }
         return commentId;
-      } finally {
-        appendCommentProcedure.close();
-      }
     } catch (final SQLException exception) {
       throw new CouldntSaveDataException(exception);
     }
@@ -116,27 +109,20 @@ public final class PostgreSQLFunctionFunctions {
 
     final String deleteFunction = " { ? = call delete_function_comment(?, ?, ?, ?) } ";
 
-    try {
-      final CallableStatement deleteCommentStatement =
-          provider.getConnection().getConnection().prepareCall(deleteFunction);
+    try (CallableStatement deleteCommentStatement =
+          provider.getConnection().getConnection().prepareCall(deleteFunction)) {
 
-      try {
         deleteCommentStatement.registerOutParameter(1, Types.INTEGER);
         deleteCommentStatement.setInt(2, function.getModule().getConfiguration().getId());
         deleteCommentStatement.setObject(3, function.getAddress().toBigInteger(), Types.BIGINT);
         deleteCommentStatement.setInt(4, commentId);
         deleteCommentStatement.setInt(5, userId);
-
         deleteCommentStatement.execute();
-
         deleteCommentStatement.getInt(1);
         if (deleteCommentStatement.wasNull()) {
           throw new IllegalArgumentException(
               "Error: The comment id returned by the database was null");
         }
-      } finally {
-        deleteCommentStatement.close();
-      }
     } catch (final SQLException exception) {
       throw new CouldntDeleteException(exception);
     }
@@ -192,11 +178,9 @@ public final class PostgreSQLFunctionFunctions {
     final String query = "UPDATE " + CTableNames.FUNCTIONS_TABLE + " SET parent_module_id = ?, "
         + " parent_module_function = ? WHERE module_id = ? AND address = ?";
 
-    try {
-      final PreparedStatement statement =
-          provider.getConnection().getConnection().prepareStatement(query);
+    try (PreparedStatement statement =
+          provider.getConnection().getConnection().prepareStatement(query)) {
 
-      try {
         if (parentModuleId != null) {
           statement.setInt(1, parentModuleId);
         } else {
@@ -209,12 +193,7 @@ public final class PostgreSQLFunctionFunctions {
         }
         statement.setInt(3, source.getModule().getConfiguration().getId());
         statement.setObject(4, source.getAddress().toBigInteger().toString(), Types.BIGINT);
-
         statement.execute();
-
-      } finally {
-        statement.close();
-      }
 
     } catch (final SQLException e) {
       throw new CouldntSaveDataException(e);
@@ -250,18 +229,13 @@ public final class PostgreSQLFunctionFunctions {
     final String query = "UPDATE " + CTableNames.FUNCTIONS_TABLE
         + " SET description = ? WHERE module_id = ? AND address = ?";
 
-    try {
-      final PreparedStatement statement = connection.getConnection().prepareStatement(query);
+    try (PreparedStatement statement = connection.getConnection().prepareStatement(query)) {
 
-      try {
         statement.setString(1, description);
         statement.setInt(2, module);
         statement.setObject(3, address.toBigInteger(), Types.BIGINT);
-
         statement.executeUpdate();
-      } finally {
-        statement.close();
-      }
+        
     } catch (final SQLException exception) {
       throw new CouldntSaveDataException(exception);
     }
@@ -295,18 +269,13 @@ public final class PostgreSQLFunctionFunctions {
     final String query = "UPDATE " + CTableNames.FUNCTIONS_TABLE
         + " SET name = ? WHERE module_id = ? and address = ?";
 
-    try {
-      final PreparedStatement statement = connection.getConnection().prepareStatement(query);
+    try (PreparedStatement statement = connection.getConnection().prepareStatement(query)) {
 
-      try {
         statement.setString(1, name);
         statement.setInt(2, module);
         statement.setObject(3, address.toBigInteger(), java.sql.Types.BIGINT);
-
         statement.executeUpdate();
-      } finally {
-        statement.close();
-      }
+      
     } catch (final SQLException exception) {
       throw new CouldntSaveDataException(exception);
     }

--- a/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Functions/PostgreSQLSectionFunctions.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Functions/PostgreSQLSectionFunctions.java
@@ -72,11 +72,10 @@ public class PostgreSQLSectionFunctions {
     Preconditions.checkNotNull(endAddress, "Error: endAddress argument can not be null");
     Preconditions.checkNotNull(permission, "Error: permission argument can not be null");
 
+    final String query = " { ? = call create_section( ?, ?, ?, ?, ?, ?, ?) } ";
     try (CallableStatement createSectionProcedure = connection.prepareCall(query)) {
-      final String query = " { ? = call create_section( ?, ?, ?, ?, ?, ?, ?) } ";
 
         createSectionProcedure.registerOutParameter(1, Types.INTEGER);
-
         createSectionProcedure.setInt(2, moduleId);
         createSectionProcedure.setString(3, name);
         if (commentId == null) {

--- a/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Functions/PostgresSQLDebuggerFunctions.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Functions/PostgresSQLDebuggerFunctions.java
@@ -71,30 +71,23 @@ public final class PostgresSQLDebuggerFunctions {
 
     final CConnection connection = provider.getConnection();
 
-    try {
-      final String query =
+    final String query =
           "INSERT INTO " + CTableNames.DEBUGGERS_TABLE
               + "(name, host, port) VALUES(?, ?, ?) RETURNING id";
-
-      final PreparedStatement statement = connection.getConnection().prepareStatement(query);
+              
+    try (PreparedStatement statement = connection.getConnection().prepareStatement(query);
+         ResultSet resultSet = statement.executeQuery()) {
 
       statement.setString(1, name);
       statement.setString(2, host);
       statement.setInt(3, port);
 
-      final ResultSet resultSet = statement.executeQuery();
-
       int id = -1;
 
-      try {
         while (resultSet.next()) {
           id = resultSet.getInt("id");
         }
-      } finally {
-        resultSet.close();
-        statement.close();
-      }
-
+      
       return new DebuggerTemplate(id, name, host, port, provider);
 
     } catch (final SQLException e) {
@@ -139,10 +132,8 @@ public final class PostgresSQLDebuggerFunctions {
     final CConnection connection = provider.getConnection();
     final String query = "SELECT * FROM " + CTableNames.DEBUGGERS_TABLE;
 
-    try {
-      final ResultSet resultSet = connection.executeQuery(query, true);
-
-      try {
+    try (ResultSet resultSet = connection.executeQuery(query, true)) {
+        
         while (resultSet.next()) {
           final DebuggerTemplate debugger =
               new DebuggerTemplate(resultSet.getInt("id"), PostgreSQLHelpers.readString(resultSet,
@@ -151,9 +142,7 @@ public final class PostgresSQLDebuggerFunctions {
 
           manager.addDebugger(debugger);
         }
-      } finally {
-        resultSet.close();
-      }
+        
     } catch (final SQLException e) {
       throw new CouldntLoadDataException(e);
     }
@@ -179,18 +168,13 @@ public final class PostgresSQLDebuggerFunctions {
 
     final String query = "UPDATE " + CTableNames.DEBUGGERS_TABLE + " SET host = ? WHERE id = ?";
 
-    try {
-      final PreparedStatement statement =
-          provider.getConnection().getConnection().prepareStatement(query);
-
-      try {
+    try (PreparedStatement statement =
+          provider.getConnection().getConnection().prepareStatement(query)) {
+      
         statement.setString(1, host);
         statement.setInt(2, debugger.getId());
-
         statement.executeUpdate();
-      } finally {
-        statement.close();
-      }
+      
     } catch (final SQLException e) {
       throw new CouldntSaveDataException(e);
     }
@@ -215,18 +199,13 @@ public final class PostgresSQLDebuggerFunctions {
         "IE00427: Debugger is not part of this database");
     final String query = "UPDATE " + CTableNames.DEBUGGERS_TABLE + " SET name = ? WHERE id = ?";
 
-    try {
-      final PreparedStatement statement =
-          provider.getConnection().getConnection().prepareStatement(query);
+    try (PreparedStatement statement =
+          provider.getConnection().getConnection().prepareStatement(query)) {
 
-      try {
         statement.setString(1, name);
         statement.setInt(2, debugger.getId());
-
         statement.executeUpdate();
-      } finally {
-        statement.close();
-      }
+      
     } catch (final SQLException e) {
       throw new CouldntSaveDataException(e);
     }
@@ -253,19 +232,13 @@ public final class PostgresSQLDebuggerFunctions {
 
     final String query = "UPDATE " + CTableNames.DEBUGGERS_TABLE + " SET port = ? WHERE id = ?";
 
-    try {
-      final PreparedStatement statement =
-          provider.getConnection().getConnection().prepareStatement(query);
-
-      try {
+    try (PreparedStatement statement =
+          provider.getConnection().getConnection().prepareStatement(query)) {
+      
         statement.setInt(1, port);
         statement.setInt(2, debugger.getId());
-
         statement.executeUpdate();
-      } finally {
-        statement.close();
-      }
-
+      
     } catch (final SQLException e) {
       throw new CouldntSaveDataException(e);
     }

--- a/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Loaders/PostgreSQLGroupNodeLoader.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Loaders/PostgreSQLGroupNodeLoader.java
@@ -74,9 +74,7 @@ public final class PostgreSQLGroupNodeLoader {
             + " FROM " + CTableNames.NODES_TABLE + " JOIN " + CTableNames.GROUP_NODES_TABLE
             + " ON id = node_id WHERE view_id = " + view.getConfiguration().getId();
 
-    final ResultSet resultSet = provider.getConnection().executeQuery(query, true);
-
-    try {
+    try (ResultSet resultSet = provider.getConnection().executeQuery(query, true)) {
       while (resultSet.next()) {
         final int nodeId = resultSet.getInt("id");
         Integer commentId = resultSet.getInt("comment_id");
@@ -115,8 +113,6 @@ public final class PostgreSQLGroupNodeLoader {
         }
       }
 
-    } finally {
-      resultSet.close();
     }
   }
 
@@ -135,13 +131,11 @@ public final class PostgreSQLGroupNodeLoader {
         "SELECT id, parent_id FROM " + CTableNames.NODES_TABLE + " WHERE view_id = "
             + view.getConfiguration().getId() + " ORDER BY id";
 
-    final ResultSet resultSet = connection.executeQuery(query, true);
-
     int counter = 0;
 
     int firstId = -1;
 
-    try {
+    try (ResultSet resultSet = connection.executeQuery(query, true)) {
       while (resultSet.next()) {
         if (firstId == -1) {
           firstId = resultSet.getInt("id");
@@ -159,8 +153,6 @@ public final class PostgreSQLGroupNodeLoader {
 
         counter++;
       }
-    } finally {
-      resultSet.close();
     }
   }
 }

--- a/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/PostgreSQLDataImporter.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/PostgreSQLDataImporter.java
@@ -56,8 +56,9 @@ public final class PostgreSQLDataImporter {
       throws SQLException {
     Preconditions.checkNotNull(connection, "IE00207: provider argument can not be null");
 
+    final String query = "SELECT architecture FROM modules WHERE id = " + rawModuleId;
     try (ResultSet resultSet =
-        connection.executeQuery("SELECT architecture FROM modules WHERE id = " + rawModuleId, true)) {
+        connection.executeQuery(query, true)) {
       while (resultSet.next()) {
         return PostgreSQLHelpers.readString(resultSet, "architecture");
       }

--- a/src/main/java/com/google/security/zynamics/reil/algorithms/mono/AbstractInstructionTracker.java
+++ b/src/main/java/com/google/security/zynamics/reil/algorithms/mono/AbstractInstructionTracker.java
@@ -119,44 +119,43 @@ public abstract class AbstractInstructionTracker<LatticeElement extends ILattice
   {
     final ReilInstruction instruction = node.getInstruction();
 
-    final String mnemonic = instruction.getMnemonic();
-
-    if (mnemonic.equals(ReilHelpers.OPCODE_ADD)) {
-      return transformAdd(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_AND)) {
-      return transformAnd(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_BISZ)) {
-      return transformBisz(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_BSH)) {
-      return transformBsh(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_DIV)) {
-      return transformDiv(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_JCC)) {
-      return transformJcc(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_LDM)) {
-      return transformLdm(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_MOD)) {
-      return transformMod(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_MUL)) {
-      return transformMul(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_NOP)) {
-      return transformNop(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_OR)) {
-      return transformOr(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_STM)) {
-      return transformStm(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_STR)) {
-      return transformStr(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_SUB)) {
-      return transformSub(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_UNDEF)) {
-      return transformUndef(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_UNKNOWN)) {
-      return transformUnknown(instruction, currentState, incomingState);
-    } else if (mnemonic.equals(ReilHelpers.OPCODE_XOR)) {
-      return transformXor(instruction, currentState, incomingState);
-    } else {
-      return transformUnknownOpcode(instruction, currentState, incomingState);
-    }
+    switch (instruction.getMnemonic()) {
+        case ReilHelpers.OPCODE_ADD:
+            return transformAdd(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_AND:
+            return transformAnd(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_BISZ:
+            return transformBisz(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_BSH:
+            return transformBsh(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_DIV:
+            return transformDiv(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_JCC:
+            return transformJcc(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_LDM:
+            return transformLdm(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_MOD:
+            return transformMod(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_MUL:
+            return transformMul(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_NOP:
+            return transformNop(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_OR:
+            return transformOr(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_STM:
+            return transformStm(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_STR:
+            return transformStr(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_SUB:
+            return transformSub(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_UNDEF:
+            return transformUndef(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_UNKNOWN:
+            return transformUnknown(instruction, currentState, incomingState);
+        case ReilHelpers.OPCODE_XOR:
+            return transformXor(instruction, currentState, incomingState);
+        default:
+            return transformUnknownOpcode(instruction, currentState, incomingState);
+    } 
   }
 }

--- a/src/test/java/com/google/security/zynamics/binnavi/GuitarTests.java
+++ b/src/test/java/com/google/security/zynamics/binnavi/GuitarTests.java
@@ -71,7 +71,7 @@ public final class GuitarTests {
     try {
       final IntegrationTestSetup setup = new IntegrationTestSetup();
       setup.createIntegrationTestDatabase();
-    } catch (IOException | SQLException e) {
+    } catch (final SQLException e) {
       e.printStackTrace();
     } 
   }

--- a/src/test/java/com/google/security/zynamics/binnavi/IntegrationTestSetup.java
+++ b/src/test/java/com/google/security/zynamics/binnavi/IntegrationTestSetup.java
@@ -150,9 +150,8 @@ public class IntegrationTestSetup {
    * database are initialized. This order is essential to avoid foreign key violations.
    *
    * @param databaseName The name of the database to create.
-   * @throws IOException if the {@link FileReader reader} could not be closed.
    */
-  private void createDatabase(final String databaseName) throws IOException {
+  private void createDatabase(final String databaseName) {
 
     try {
       final Connection connection =
@@ -220,7 +219,7 @@ public class IntegrationTestSetup {
    * @throws SQLException if one of the queries for drop or create fail.
    * @throws IOException
    */
-  public void createIntegrationTestDatabase() throws SQLException, IOException {
+  public void createIntegrationTestDatabase() throws SQLException {
 
     final Connection connection = DriverManager.getConnection(url + "postgres", databaseProperties);
 


### PR DESCRIPTION
Change `try-finally` block to the Java7's `try-with-resources` construction. Finally blocks and close operations can be excluded becouse `PreparedStatement` and `ResultSet` classes implement `AutoCloseable` intrface.
