### PR TITLE
Fix error when connecting to a new database.

### DIFF
--- a/src/main/java/com/google/security/zynamics/binnavi/Database/CGenericSQLUserFunctions.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/CGenericSQLUserFunctions.java
@@ -54,11 +54,11 @@ public class CGenericSQLUserFunctions {
 
     CUser user = null;
 
-    try (PreparedStatement statement = connection.prepareStatement(query);
-         ResultSet resultSet = statement.executeQuery()) {
-        
+    try (PreparedStatement statement = connection.prepareStatement(query)) {
         statement.setString(1, userName);
-       
+        
+        ResultSet resultSet = statement.executeQuery();
+        
         while (resultSet.next()) {
           user = new CUser(resultSet.getInt(1), userName);
         }

--- a/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Creators/PostgreSQLProjectCreator.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Creators/PostgreSQLProjectCreator.java
@@ -97,9 +97,10 @@ public final class PostgreSQLProjectCreator {
 
         try (PreparedStatement statement =
           connection.getConnection().prepareStatement(query, ResultSet.TYPE_SCROLL_INSENSITIVE,
-              ResultSet.CONCUR_READ_ONLY);
-           ResultSet resultSet = statement.executeQuery()) {
+              ResultSet.CONCUR_READ_ONLY)) {
         statement.setString(1, name);
+        
+        ResultSet resultSet = statement.executeQuery()
 
         Integer id = null;
 

--- a/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Creators/PostgreSQLProjectCreator.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/PostgreSQL/Creators/PostgreSQLProjectCreator.java
@@ -100,7 +100,7 @@ public final class PostgreSQLProjectCreator {
               ResultSet.CONCUR_READ_ONLY)) {
         statement.setString(1, name);
         
-        ResultSet resultSet = statement.executeQuery()
+        ResultSet resultSet = statement.executeQuery();
 
         Integer id = null;
 


### PR DESCRIPTION
On my system, binnavi crashes when connecting to a new database. This is due to a tiny bug where statement.setString was execute after executeQuery. I have just reversed the two statements in a couple spots :).

P. S. The exception thrown is this:

```
org.postgresql.util.PSQLException: No value specified for parameter 1.
    at org.postgresql.core.v3.SimpleParameterList.checkAllParametersSet(SimpleParameterList.java:228)
    at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:245)
    at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:570)
    at org.postgresql.jdbc2.AbstractJdbc2Statement.executeWithFlags(AbstractJdbc2Statement.java:420)
    at org.postgresql.jdbc2.AbstractJdbc2Statement.executeQuery(AbstractJdbc2Statement.java:305)
    at com.google.security.zynamics.binnavi.Database.CGenericSQLUserFunctions.addUser(CGenericSQLUserFunctions.java:58)
    at com.google.security.zynamics.binnavi.Database.PostgreSQLProvider.addUser(PostgreSQLProvider.java:150)
    at com.google.security.zynamics.binnavi.Gui.Users.CUserManager.addUser(CUserManager.java:153)
    at com.google.security.zynamics.binnavi.Database.CDatabase.loadUserManager(CDatabase.java:198)
    at com.google.security.zynamics.binnavi.Database.CDatabase.load(CDatabase.java:404)
    at com.google.security.zynamics.binnavi.Database.CDatabaseLoader.loadDatabase(CDatabaseLoader.java:71)
    at com.google.security.zynamics.binnavi.Gui.MainWindow.Implementations.CDatabaseConnectionFunctions$1.run(CDatabaseConnectionFunctions.java:68)
```
