### PR TITLE
Use the existing RetnTranslator to translate the X86 retn instruction

### DIFF
--- a/src/main/java/com/google/security/zynamics/reil/translators/x86/TranslatorX86.java
+++ b/src/main/java/com/google/security/zynamics/reil/translators/x86/TranslatorX86.java
@@ -192,6 +192,7 @@ public class TranslatorX86<InstructionType extends IInstruction> implements
       translators.put("repne scasw", new RepneTranslator(new ScasGenerator(), OperandSize.WORD));
       translators.put("repne scasd", new RepneTranslator(new ScasGenerator(), OperandSize.DWORD));
       translators.put("ret", new RetnTranslator());
+      translators.put("retn", new RetnTranslator());
       translators.put("rcl", new RclTranslator());
       translators.put("rcr", new RcrTranslator());
       translators.put("rol", new RolTranslator());


### PR DESCRIPTION
The `retn` instruction was being labelled as an "unknown mnemonic", even though (to the best of my knowledge) `retn` is an "exact synonym" for the `ret` instruction (source: https://courses.engr.illinois.edu/ece390/archive/spr2002/books/labmanual/inst-ref-ret.html).

Therefore, I've reused the existing `RetnTranslator` to translate `retn` instructions.
