### PR TITLE
Automatic connection fix

### DIFF
--- a/src/main/java/com/google/security/zynamics/binnavi/Database/CConnection.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Database/CConnection.java
@@ -48,12 +48,12 @@ public final class CConnection {
   /**
    * Configuration for the database connection.
    */
-  private static CDatabaseConfiguration m_databaseConfiguration;
+  private CDatabaseConfiguration m_databaseConfiguration;
 
   /**
    * Current database connection properties.
    */
-  private static Properties m_properties;
+  private Properties m_properties;
 
   /**
    * Connection to the database.


### PR DESCRIPTION
Fixed loading for several databases with "connect automatically" checkbox

Databases are loading in parallel. So CConnection fields shouldn't be static for race conditions evading.
