### PR TITLE
!): Fix "yfileswrap-obfuscated" version for gradle build.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compile group: 'xml-apis', name: 'xml-apis', version: '1.4.01'
     compile group: 'xml-apis', name: 'xml-apis-ext', version: '1.3.04'
     compile group: 'net.sf.proguard', name: 'proguard-base', version: '5.2.1'
-    compile group: 'com.google.security.zynamics.binnavi', name: 'yfileswrap-obfuscated', version: '6.0'
+    compile group: 'com.google.security.zynamics.binnavi', name: 'yfileswrap-obfuscated', version: '6.1'
 
     compile group: 'junit', name: 'junit', version: '4+'
 }


### PR DESCRIPTION
In build.gradle file, "yfileswrap-obfuscated" version 6.0 is 404. Fix with the correct version 6.1.
