### PR TITLE
Fix dataflow gap

### DIFF
--- a/src/main/java/com/google/security/zynamics/reil/algorithms/mono/OperandGraph.java
+++ b/src/main/java/com/google/security/zynamics/reil/algorithms/mono/OperandGraph.java
@@ -189,6 +189,10 @@ public class OperandGraph extends DirectedGraph<OperandGraphNode, OperandGraphEd
         continue;
       }
 
+      //don't link self-dependency
+      if(search.getInstruction() == instruction)
+        continue;
+
       if (ReilHelpers.writesThirdOperand(instruction.getMnemonicCode())
           && instruction.getThirdOperand().getValue().equals(value)) {
         final List<OperandGraphNode> nodes = graphMap.get(block).first();


### PR DESCRIPTION
Self-dependencies of instructions already described and linked in "createInitialMap" function.
In function "findDefinition" we shouldn't link self-dependencies.
For examle next two instructions won't be linked:
0000000804842302   add         t0, t1, qword t2
0000000804842303   and         qword t2, qword ffffffffh, t2
because "and" will find "and" as definition

I used the following function for testing:

```
int bad(char * user)
{
        printf(user);
}
```
