### PR TITLE
Applied automated refactoring to migrate skeletal implementations to interfaces as default methods

### DIFF
--- a/src/main/java/com/google/security/zynamics/binnavi/Gui/CriteriaDialog/Conditions/CAbstractCriterium.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Gui/CriteriaDialog/Conditions/CAbstractCriterium.java
@@ -35,10 +35,6 @@ public abstract class CAbstractCriterium implements ICriterium {
     m_listeners.addListener(listener);
   }
 
-  @Override
-  public void dispose() {
-  }
-
   /**
    * Notifies listeners that the criterium changed.
    */

--- a/src/main/java/com/google/security/zynamics/binnavi/Gui/CriteriaDialog/Conditions/ICriterium.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Gui/CriteriaDialog/Conditions/ICriterium.java
@@ -37,7 +37,8 @@ public interface ICriterium extends IAbstractCriterium {
    */
   ICachedCriterium createCachedCriterium();
 
-  void dispose();
+  default void dispose() {
+  }
 
   /**
    * Returns the description of the criterium.

--- a/src/main/java/com/google/security/zynamics/binnavi/Gui/FilterPanel/IFilterFactory.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Gui/FilterPanel/IFilterFactory.java
@@ -34,7 +34,8 @@ public interface IFilterFactory<T> {
    */
   IFilter<T> createFilter(String text) throws RecognitionException;
 
-  void dispose();
+  default void dispose() {
+  }
 
   /**
    * Returns the optional filter component that is shown next to the filter text field above
@@ -42,5 +43,7 @@ public interface IFilterFactory<T> {
    * 
    * @return The filter component or null.
    */
-  IFilterComponent<T> getFilterComponent();
+  default IFilterComponent<T> getFilterComponent() {
+    return null;
+  }
 }

--- a/src/main/java/com/google/security/zynamics/binnavi/Gui/MainWindow/ProjectTree/Nodes/Views/Component/CViewsTable.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Gui/MainWindow/ProjectTree/Nodes/Views/Component/CViewsTable.java
@@ -157,11 +157,6 @@ public abstract class CViewsTable extends CAbstractTreeTable<INaviView> implemen
   }
 
   @Override
-  public int getNameColumn() {
-    return 0;
-  }
-
-  @Override
   public CAbstractTreeViewsTableModel getTreeTableModel() {
     return viewsTableModel;
   }

--- a/src/main/java/com/google/security/zynamics/binnavi/Gui/MainWindow/ProjectTree/Nodes/Views/Component/IViewsTable.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Gui/MainWindow/ProjectTree/Nodes/Views/Component/IViewsTable.java
@@ -29,7 +29,9 @@ public interface IViewsTable {
    * 
    * @return The view name column index.
    */
-  int getNameColumn();
+  default int getNameColumn() {
+    return 0;
+  }
 
   /**
    * Returns the view from the given unsorted index.

--- a/src/main/java/com/google/security/zynamics/binnavi/Gui/MainWindow/ProjectTree/filters/CDefaultFilterCreator.java
+++ b/src/main/java/com/google/security/zynamics/binnavi/Gui/MainWindow/ProjectTree/filters/CDefaultFilterCreator.java
@@ -162,13 +162,4 @@ public abstract class CDefaultFilterCreator<T, WrapperType> implements IFilterFa
 
     return null;
   }
-
-  @Override
-  public void dispose() {
-  }
-
-  @Override
-  public IFilterComponent<T> getFilterComponent() {
-    return null;
-  }
 }

--- a/src/main/java/com/google/security/zynamics/zylib/gui/ProgressDialogs/CEndlessHelperThread.java
+++ b/src/main/java/com/google/security/zynamics/zylib/gui/ProgressDialogs/CEndlessHelperThread.java
@@ -59,10 +59,6 @@ public abstract class CEndlessHelperThread extends Thread implements IEndlessPro
     m_listeners.addListener(listener);
   }
 
-  @Override
-  public void closeRequested() {
-  }
-
   public Exception getException() {
     return m_exception;
   }

--- a/src/main/java/com/google/security/zynamics/zylib/gui/ProgressDialogs/CStandardHelperThread.java
+++ b/src/main/java/com/google/security/zynamics/zylib/gui/ProgressDialogs/CStandardHelperThread.java
@@ -53,11 +53,6 @@ public abstract class CStandardHelperThread extends Thread implements IStandardP
     m_listeners.addListener(listener);
   }
 
-  @Override
-  public void closeRequested() {
-    // Do nothing
-  }
-
   public Exception getException() {
     return m_exception;
   }

--- a/src/main/java/com/google/security/zynamics/zylib/gui/ProgressDialogs/IEndlessProgressModel.java
+++ b/src/main/java/com/google/security/zynamics/zylib/gui/ProgressDialogs/IEndlessProgressModel.java
@@ -18,7 +18,8 @@ package com.google.security.zynamics.zylib.gui.ProgressDialogs;
 public interface IEndlessProgressModel {
   void addProgressListener(IEndlessProgressListener listener);
 
-  void closeRequested();
+  default void closeRequested() {
+  }
 
   void removeProgressListener(IEndlessProgressListener listener);
 }

--- a/src/main/java/com/google/security/zynamics/zylib/gui/ProgressDialogs/IStandardProgressModel.java
+++ b/src/main/java/com/google/security/zynamics/zylib/gui/ProgressDialogs/IStandardProgressModel.java
@@ -18,7 +18,9 @@ package com.google.security.zynamics.zylib.gui.ProgressDialogs;
 public interface IStandardProgressModel {
   void addProgressListener(IStandardProgressListener listener);
 
-  void closeRequested();
+  default void closeRequested() {
+    // Do nothing
+  }
 
   void removeProgressListener(IStandardProgressListener listener);
 }

--- a/src/main/java/com/google/security/zynamics/zylib/gui/zygraph/edges/IViewEdgeListener.java
+++ b/src/main/java/com/google/security/zynamics/zylib/gui/zygraph/edges/IViewEdgeListener.java
@@ -18,27 +18,39 @@ package com.google.security.zynamics.zylib.gui.zygraph.edges;
 import java.awt.Color;
 
 public interface IViewEdgeListener {
-  void addedBend(IViewEdge<?> edge, CBend path);
+  default void addedBend(IViewEdge<?> edge, CBend path) {
+  }
 
-  void changedColor(CViewEdge<?> edge, Color color);
+  default void changedColor(CViewEdge<?> edge, Color color) {
+  }
 
-  void changedSelection(IViewEdge<?> edge, boolean selected);
+  default void changedSelection(IViewEdge<?> edge, boolean selected) {
+  }
 
-  void changedSourceX(CViewEdge<?> edge, double sourceX);
+  default void changedSourceX(CViewEdge<?> edge, double sourceX) {
+  }
 
-  void changedSourceY(CViewEdge<?> edge, double sourceY);
+  default void changedSourceY(CViewEdge<?> edge, double sourceY) {
+  }
 
-  void changedTargetX(CViewEdge<?> edge, double targetX);
+  default void changedTargetX(CViewEdge<?> edge, double targetX) {
+  }
 
-  void changedTargetY(CViewEdge<?> edge, double targetY);
+  default void changedTargetY(CViewEdge<?> edge, double targetY) {
+  }
 
-  void changedType(CViewEdge<?> edge, EdgeType type);
+  default void changedType(CViewEdge<?> edge, EdgeType type) {
+  }
 
-  void changedVisibility(IViewEdge<?> edge, boolean visibility);
+  default void changedVisibility(IViewEdge<?> edge, boolean visibility) {
+  }
 
-  void clearedBends(IViewEdge<?> edge);
+  default void clearedBends(IViewEdge<?> edge) {
+  }
 
-  void insertedBend(IViewEdge<?> edge, int index, CBend path);
+  default void insertedBend(IViewEdge<?> edge, int index, CBend path) {
+  }
 
-  void removedBend(CViewEdge<?> edge, int index, CBend path);
+  default void removedBend(CViewEdge<?> edge, int index, CBend path) {
+  }
 }

--- a/src/main/java/com/google/security/zynamics/zylib/gui/zygraph/edges/ViewEdgeListenerAdapter.java
+++ b/src/main/java/com/google/security/zynamics/zylib/gui/zygraph/edges/ViewEdgeListenerAdapter.java
@@ -15,55 +15,5 @@ limitations under the License.
 */
 package com.google.security.zynamics.zylib.gui.zygraph.edges;
 
-import java.awt.Color;
-
 public abstract class ViewEdgeListenerAdapter implements IViewEdgeListener {
-
-  @Override
-  public void addedBend(final IViewEdge<?> edge, final CBend path) {
-  }
-
-  @Override
-  public void changedColor(final CViewEdge<?> edge, final Color color) {
-  }
-
-  @Override
-  public void changedSelection(final IViewEdge<?> edge, final boolean selected) {
-  }
-
-  @Override
-  public void changedSourceX(final CViewEdge<?> edge, final double sourceX) {
-  }
-
-  @Override
-  public void changedSourceY(final CViewEdge<?> edge, final double sourceY) {
-  }
-
-  @Override
-  public void changedTargetX(final CViewEdge<?> edge, final double targetX) {
-  }
-
-  @Override
-  public void changedTargetY(final CViewEdge<?> edge, final double targetY) {
-  }
-
-  @Override
-  public void changedType(final CViewEdge<?> edge, final EdgeType type) {
-  }
-
-  @Override
-  public void changedVisibility(final IViewEdge<?> edge, final boolean visibility) {
-  }
-
-  @Override
-  public void clearedBends(final IViewEdge<?> edge) {
-  }
-
-  @Override
-  public void insertedBend(final IViewEdge<?> edge, final int index, final CBend path) {
-  }
-
-  @Override
-  public void removedBend(final CViewEdge<?> edge, final int index, final CBend path) {
-  }
 }

--- a/src/main/java/com/google/security/zynamics/zylib/yfileswrap/gui/zygraph/realizers/IZyNodeRealizer.java
+++ b/src/main/java/com/google/security/zynamics/zylib/yfileswrap/gui/zygraph/realizers/IZyNodeRealizer.java
@@ -60,7 +60,18 @@ public interface IZyNodeRealizer {
 
   boolean isVisible();
 
-  int positionToRow(double y);
+  default int positionToRow(double y) {
+    // TODO: This does not really work because line heights are not constant.
+
+    final ZyLabelContent content = getNodeContent();
+
+    final Rectangle2D contentBounds = getNodeContent().getBounds();
+    final double yratio = getHeight() / contentBounds.getHeight();
+
+    final int row = (int) ((y / yratio - content.getPaddingTop()) / content.getLineHeight());
+
+    return row >= content.getLineCount() ? -1 : row;
+  }
 
   void regenerate();
 
@@ -68,7 +79,11 @@ public interface IZyNodeRealizer {
 
   void repaint();
 
-  double rowToPosition(int line);
+  default double rowToPosition(int row) {
+    final ZyLabelContent content = getNodeContent();
+
+    return content.getPaddingTop() + row * content.getLineHeight();
+  }
 
   void setFillColor(Color color);
 
@@ -88,5 +103,12 @@ public interface IZyNodeRealizer {
 
   void setY(double y);
 
-  void updateContentSelectionColor();
+  default void updateContentSelectionColor() {
+    // TODO: This is kind of a hack, should be improved
+    final ZyLabelContent content = getNodeContent();
+
+    if (content.isSelectable()) {
+      content.updateContentSelectionColor(getFillColor(), isSelected());
+    }
+  }
 }

--- a/src/main/java/com/google/security/zynamics/zylib/yfileswrap/gui/zygraph/realizers/ZyNodeRealizer.java
+++ b/src/main/java/com/google/security/zynamics/zylib/yfileswrap/gui/zygraph/realizers/ZyNodeRealizer.java
@@ -159,27 +159,6 @@ implements IZyNodeRealizer {
   }
 
   /**
-   * Converts a y coordinate into a line number of the node content.
-   *
-   * @param y The y coordinate.
-   * @return The number of the line shown at the y address or -1 if there is no line at the given
-   *         coordinates.
-   */
-  @Override
-  public int positionToRow(final double y) {
-    // TODO: This does not really work because line heights are not constant.
-
-    final ZyLabelContent content = getNodeContent();
-
-    final Rectangle2D contentBounds = getNodeContent().getBounds();
-    final double yratio = getHeight() / contentBounds.getHeight();
-
-    final int row = (int) ((y / yratio - content.getPaddingTop()) / content.getLineHeight());
-
-    return row >= content.getLineCount() ? -1 : row;
-  }
-
-  /**
    * Regenerates the content of the realizer.
    */
   @Override
@@ -215,13 +194,6 @@ implements IZyNodeRealizer {
   @Override
   public void removeListener(final IZyNodeRealizerListener<?> listener) {
     m_listeners.removeListener(listener);
-  }
-
-  @Override
-  public double rowToPosition(final int row) {
-    final ZyLabelContent content = getNodeContent();
-
-    return content.getPaddingTop() + row * content.getLineHeight();
   }
 
   @Override
@@ -320,16 +292,6 @@ implements IZyNodeRealizer {
           CUtilityFunctions.logException(exception);
         }
       }
-    }
-  }
-
-  @Override
-  public void updateContentSelectionColor() {
-    // TODO: This is kind of a hack, should be improved
-    final ZyLabelContent content = getNodeContent();
-
-    if (content.isSelectable()) {
-      content.updateContentSelectionColor(getFillColor(), isSelected());
     }
   }
 }


### PR DESCRIPTION
This is a **semantics-preserving** automated refactoring that migrates existing method implementations in classes to the corresponding implemented interface methods as `default` methods. The tool **does not** add new code; it only rearranges _existing_ code.
- We are evaluating a research prototype automated refactoring Eclipse plug-in called [Migrate Skeletal Implementation to Interface](https://github.com/khatchad/Migrate-Skeletal-Implementation-to-Interface-Refactoring). We have applied the tool to your project in the hopes of receiving feedback.
- The approach is very conservative. Specifically, it only performs a migration if the target interface is unambiguous. That may mean that not all changes that can be made were made. Please feel free to continue the refactoring manually if you wish.
- We only migrated methods declared in abstract classes. We believe such methods to be likely suitable default methods in corresponding interfaces.
- The source code should be semantically equivalent to the original.
- The refactoring resulted in an empty class. Please let us know if you would like us to remove this class.

Thank you for your help in this evaluation! Any feedback you can provide would be very helpful. In particular, we are interested if _each_ of the proposed changes are helpful or not.
